### PR TITLE
Adjust how the socket is checked if it is "connected".

### DIFF
--- a/src/FreeDSx/Socket/Socket.php
+++ b/src/FreeDSx/Socket/Socket.php
@@ -164,7 +164,9 @@ class Socket
      */
     public function isConnected() : bool
     {
-        return $this->socket !== null && !@\feof($this->socket);
+        // The is_resource() function will also check if a resource is connected or not.
+        // Previously this used feof(), which was no reliable on PHP 8.2 with certain transports.
+        return \is_resource($this->socket);
     }
 
     /**

--- a/tests/spec/FreeDSx/Socket/SocketServerSpec.php
+++ b/tests/spec/FreeDSx/Socket/SocketServerSpec.php
@@ -56,6 +56,9 @@ class SocketServerSpec extends ObjectBehavior
         $this->beConstructedThrough('bindTcp', ['0.0.0.0', 33389]);
 
         $this->getOptions()->shouldHaveKeyWithValue('transport', 'tcp');
+        $this->isConnected()->shouldBeEqualTo(true);
+        $this->close();
+        $this->isConnected()->shouldBeEqualTo(false);
     }
 
     function it_should_construct_a_udp_based_socket_server()
@@ -74,6 +77,9 @@ class SocketServerSpec extends ObjectBehavior
         $this->beConstructedThrough('bindUnix', [$this->testSocket]);
 
         $this->getOptions()->shouldHaveKeyWithValue('transport', 'unix');
+        $this->isConnected()->shouldBeEqualTo(true);
+        $this->close();
+        $this->isConnected()->shouldBeEqualTo(false);
     }
 
     function it_should_receive_data()


### PR DESCRIPTION
This fixes the behavior of `isConnected()` on a socket in PHP 8.2. This method should work on previous PHP versions as well.