### PR TITLE
[1.0.0] Add a way to close the socket FD without fully calling shutdown.

### DIFF
--- a/src/FreeDSx/Socket/Socket.php
+++ b/src/FreeDSx/Socket/Socket.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Socket;
 
 use FreeDSx\Socket\Exception\ConnectionException;
+use function fclose;
 use function fread;
 use function fwrite;
 use function stream_context_create;
@@ -122,10 +123,15 @@ class Socket
         return $this->isEncrypted;
     }
 
-    public function close(): static
+    /**
+     * @param bool $shutdown False closes only this process's FD copy without affecting shared socket state.
+     */
+    public function close(bool $shutdown = true): static
     {
         if ($this->socket !== null) {
-            stream_socket_shutdown($this->socket, STREAM_SHUT_RDWR);
+            $shutdown
+                ? stream_socket_shutdown($this->socket, STREAM_SHUT_RDWR)
+                : fclose($this->socket);
         }
         $this->socket = null;
         $this->isEncrypted = false;

--- a/tests/unit/SocketTest.php
+++ b/tests/unit/SocketTest.php
@@ -162,6 +162,28 @@ final class SocketTest extends TestCase
         self::assertFalse($subject->isConnected());
     }
 
+    public function test_close_without_shutdown_disconnects_tcp(): void
+    {
+        $subject = Socket::tcp(
+            'www.google.com',
+            (new SocketOptions())->setPort(80),
+        );
+
+        self::assertTrue($subject->isConnected());
+        $subject->close(shutdown: false);
+        self::assertFalse($subject->isConnected());
+    }
+
+    public function test_close_without_shutdown_disconnects_unix(): void
+    {
+        $path = $this->createUnixServer();
+        $subject = Socket::unix($path);
+
+        self::assertTrue($subject->isConnected());
+        $subject->close(shutdown: false);
+        self::assertFalse($subject->isConnected());
+    }
+
     public function test_it_should_return_at_most_buffer_size_bytes_per_read(): void
     {
         [$local, $remote] = $this->createSocketPair();


### PR DESCRIPTION
I need this in the LDAP library. We need to be able to clean-up the original server socket after forking so we don't cause issues on server shutdown.