### PR TITLE
[1.0.0] Add a write timeout enforcer so we can make a distinction in strategies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,12 @@
     "phpunit/phpunit": "^11.5",
     "phpstan/phpstan": "^2.0",
     "phpstan/phpstan-phpunit": "^2.0",
-    "phpstan/extension-installer": "^1.4"
+    "phpstan/extension-installer": "^1.4",
+    "swoole/ide-helper": "^6.0"
   },
   "suggest": {
     "ext-openssl": "For SSL/TLS support.",
+    "ext-swoole": "For the coroutine-aware SwooleTimerEnforcer write timeout strategy.",
     "freedsx/asn1": "For ASN.1 based message queues."
   },
   "autoload": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,5 +2,7 @@ parameters:
     level: max
     paths:
         - %currentWorkingDirectory%/src
+    scanDirectories:
+        - %currentWorkingDirectory%/vendor/swoole/ide-helper/src
     phpVersion: 80200
     treatPhpDocTypesAsCertain: false

--- a/phpstan.tests.neon
+++ b/phpstan.tests.neon
@@ -3,3 +3,5 @@ parameters:
     level: max
     paths:
         - %currentWorkingDirectory%/tests
+    scanDirectories:
+        - %currentWorkingDirectory%/vendor/swoole/ide-helper/src

--- a/src/FreeDSx/Socket/HasSocketOptions.php
+++ b/src/FreeDSx/Socket/HasSocketOptions.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace FreeDSx\Socket;
 
+use FreeDSx\Socket\Timeout\BlockingSelectEnforcer;
+use FreeDSx\Socket\Timeout\WriteTimeoutEnforcerInterface;
 use InvalidArgumentException;
 
 /**
@@ -20,6 +22,8 @@ use InvalidArgumentException;
  */
 trait HasSocketOptions
 {
+    private ?WriteTimeoutEnforcerInterface $writeTimeoutEnforcer = null;
+
     private Transport $transport = Transport::Tcp;
 
     private int $port = 389;
@@ -236,6 +240,18 @@ trait HasSocketOptions
     public function getTimeoutWrite(): int
     {
         return $this->timeoutWrite;
+    }
+
+    public function setWriteTimeoutEnforcer(WriteTimeoutEnforcerInterface $enforcer): self
+    {
+        $this->writeTimeoutEnforcer = $enforcer;
+
+        return $this;
+    }
+
+    public function getWriteTimeoutEnforcer(): WriteTimeoutEnforcerInterface
+    {
+        return $this->writeTimeoutEnforcer ??= new BlockingSelectEnforcer();
     }
 
     public function setBufferSize(int $bufferSize): self

--- a/src/FreeDSx/Socket/Socket.php
+++ b/src/FreeDSx/Socket/Socket.php
@@ -14,21 +14,17 @@ declare(strict_types=1);
 namespace FreeDSx\Socket;
 
 use FreeDSx\Socket\Exception\ConnectionException;
-use FreeDSx\Socket\Exception\WriteTimeoutException;
+use FreeDSx\Socket\Timeout\WriteTimeoutEnforcerInterface;
 
-use function error_clear_last;
-use function error_get_last;
 use function fclose;
 use function fread;
 use function fwrite;
 use function stream_context_create;
-use function stream_select;
 use function stream_set_blocking;
 use function stream_set_timeout;
 use function stream_socket_client;
 use function stream_socket_enable_crypto;
 use function stream_socket_shutdown;
-use function substr;
 
 /**
  * Represents a generic socket.
@@ -37,8 +33,6 @@ use function substr;
  */
 class Socket
 {
-    private const WRITE_ERROR_MESSAGE = 'Unable to write to the socket.';
-
     protected bool $isEncrypted = false;
 
     /**
@@ -55,14 +49,18 @@ class Socket
 
     protected int $errorNumber = 0;
 
+    protected readonly WriteTimeoutEnforcerInterface $writeTimeoutEnforcer;
+
     /**
      * @param resource|null $resource
      */
     public function __construct(
         $resource = null,
         protected readonly SocketOptionsInterface $options = new SocketOptions(),
+        ?WriteTimeoutEnforcerInterface $writeTimeoutEnforcer = null,
     ) {
         $this->socket = $resource;
+        $this->writeTimeoutEnforcer = $writeTimeoutEnforcer ?? $this->options->getWriteTimeoutEnforcer();
         if ($this->socket !== null) {
             $this->setStreamOpts();
         }
@@ -93,95 +91,24 @@ class Socket
     public function write(string $data): static
     {
         $timeout = $this->options->getTimeoutWrite();
+        $stream = $this->getStream();
 
         if ($timeout <= 0) {
             @fwrite(
-                $this->getStream(),
+                $stream,
                 $data,
             );
 
             return $this;
         }
 
-        $this->writeWithinTimeout(
+        $this->writeTimeoutEnforcer->write(
+            $stream,
             $data,
             $timeout,
         );
 
         return $this;
-    }
-
-    /**
-     * Writes, requiring progress within the write timeout. A stalled reader throws.
-     *
-     * @throws WriteTimeoutException when the socket is not writable within the timeout.
-     * @throws ConnectionException on a write failure.
-     */
-    private function writeWithinTimeout(
-        string $data,
-        int $timeout,
-    ): void {
-        $stream = $this->getStream();
-        $remaining = $data;
-
-        // Non-blocking so fwrite returns partial counts and stream_select bounds the wait; restored after.
-        stream_set_blocking($stream, false);
-
-        try {
-            while ($remaining !== '') {
-                $write = [$stream];
-                $read = [];
-                $except = [];
-                error_clear_last();
-                $ready = @stream_select(
-                    $read,
-                    $write,
-                    $except,
-                    $timeout,
-                );
-
-                if ($ready === false) {
-                    throw new ConnectionException($this->lastWriteErrorMessage());
-                }
-                if ($ready === 0) {
-                    throw new WriteTimeoutException(sprintf(
-                        'The write operation timed out after %d seconds.',
-                        $timeout,
-                    ));
-                }
-
-                error_clear_last();
-                $written = @fwrite(
-                    $stream,
-                    $remaining,
-                );
-                if ($written === false) {
-                    throw new ConnectionException($this->lastWriteErrorMessage());
-                }
-
-                $remaining = substr(
-                    $remaining,
-                    $written,
-                );
-            }
-        } finally {
-            @stream_set_blocking(
-                $stream,
-                true,
-            );
-        }
-    }
-
-    private function lastWriteErrorMessage(): string
-    {
-        $message = self::WRITE_ERROR_MESSAGE;
-        $error = error_get_last();
-
-        if ($error !== null && $error['message'] !== '') {
-            $message .= ' ' . $error['message'];
-        }
-
-        return $message;
     }
 
     public function block(bool $block): static

--- a/src/FreeDSx/Socket/SocketOptionsInterface.php
+++ b/src/FreeDSx/Socket/SocketOptionsInterface.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace FreeDSx\Socket;
 
+use FreeDSx\Socket\Timeout\WriteTimeoutEnforcerInterface;
+
 /**
  * Read-only contract Socket consumes when given configuration.
  */
@@ -47,6 +49,8 @@ interface SocketOptionsInterface
     public function getTimeoutRead(): int;
 
     public function getTimeoutWrite(): int;
+
+    public function getWriteTimeoutEnforcer(): WriteTimeoutEnforcerInterface;
 
     /**
      * @return positive-int

--- a/src/FreeDSx/Socket/Timeout/BlockingSelectEnforcer.php
+++ b/src/FreeDSx/Socket/Timeout/BlockingSelectEnforcer.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx Socket package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Socket\Timeout;
+
+use FreeDSx\Socket\Exception\WriteTimeoutException;
+
+use function error_clear_last;
+use function fwrite;
+use function sprintf;
+use function stream_select;
+use function stream_set_blocking;
+use function substr;
+
+/**
+ * Bounds a stalled send with a blocking stream_select loop.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class BlockingSelectEnforcer implements WriteTimeoutEnforcerInterface
+{
+    use ThrowsWriteError;
+
+    public function write(
+        $stream,
+        string $data,
+        int $timeout,
+    ): void {
+        $remaining = $data;
+
+        stream_set_blocking(
+            $stream,
+            false,
+        );
+
+        try {
+            while ($remaining !== '') {
+                $write = [$stream];
+                $read = [];
+                $except = [];
+                error_clear_last();
+                $ready = @stream_select(
+                    $read,
+                    $write,
+                    $except,
+                    $timeout,
+                );
+
+                if ($ready === false) {
+                    $this->throwWriteError();
+                }
+                if ($ready === 0) {
+                    throw new WriteTimeoutException(sprintf(
+                        'The write operation timed out after %d seconds.',
+                        $timeout,
+                    ));
+                }
+
+                error_clear_last();
+                $written = @fwrite(
+                    $stream,
+                    $remaining,
+                );
+                if ($written === false) {
+                    $this->throwWriteError();
+                }
+
+                $remaining = substr(
+                    $remaining,
+                    $written,
+                );
+            }
+        } finally {
+            @stream_set_blocking(
+                $stream,
+                true,
+            );
+        }
+    }
+}

--- a/src/FreeDSx/Socket/Timeout/SwooleTimerEnforcer.php
+++ b/src/FreeDSx/Socket/Timeout/SwooleTimerEnforcer.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx Socket package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Socket\Timeout;
+
+use FreeDSx\Socket\Exception\ConnectionException;
+use FreeDSx\Socket\Exception\WriteTimeoutException;
+use Swoole\Coroutine;
+use Swoole\Timer;
+
+use function error_clear_last;
+use function fwrite;
+use function sprintf;
+use function substr;
+
+/**
+ * Bounds a stalled send with a Swoole\Timer watchdog around a coroutine write, with no per-write event-loop yield.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class SwooleTimerEnforcer implements WriteTimeoutEnforcerInterface
+{
+    use ThrowsWriteError;
+
+    public function __construct(
+        private WriteTimeoutEnforcerInterface $fallback = new BlockingSelectEnforcer(),
+    ) {}
+
+    public function write(
+        $stream,
+        string $data,
+        int $timeout,
+    ): void {
+        if (Coroutine::getCid() === -1) {
+            $this->fallback->write(
+                $stream,
+                $data,
+                $timeout,
+            );
+
+            return;
+        }
+
+        $this->writeWithinCoroutine(
+            $stream,
+            $data,
+            $timeout,
+        );
+    }
+
+    /**
+     * @param resource $stream
+     * @throws WriteTimeoutException when the timer fires before the send makes progress.
+     * @throws ConnectionException on a write failure.
+     */
+    private function writeWithinCoroutine(
+        $stream,
+        string $data,
+        int $timeout,
+    ): void {
+        $remaining = $data;
+        $coroutineId = Coroutine::getCid();
+        $timeoutMs = $timeout * 1000;
+
+        while ($remaining !== '') {
+            $timedOut = false;
+            $timerId = Timer::after(
+                $timeoutMs,
+                static function () use ($coroutineId, &$timedOut): void {
+                    $timedOut = true;
+                    Coroutine::cancel($coroutineId);
+                },
+            );
+
+            error_clear_last();
+            $written = @fwrite(
+                $stream,
+                $remaining,
+            );
+            if ($timerId !== false) {
+                Timer::clear($timerId);
+            }
+
+            if ($timedOut) {
+                throw new WriteTimeoutException(sprintf(
+                    'The write operation timed out after %d seconds.',
+                    $timeout,
+                ));
+            }
+            if ($written === false) {
+                $this->throwWriteError();
+            }
+
+            $remaining = substr(
+                $remaining,
+                $written,
+            );
+        }
+    }
+}

--- a/src/FreeDSx/Socket/Timeout/ThrowsWriteError.php
+++ b/src/FreeDSx/Socket/Timeout/ThrowsWriteError.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx Socket package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Socket\Timeout;
+
+use FreeDSx\Socket\Exception\ConnectionException;
+
+use function error_get_last;
+
+/**
+ * Shared write-failure throwing for the write timeout enforcers.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+trait ThrowsWriteError
+{
+    private const WRITE_ERROR_MESSAGE = 'Unable to write to the socket.';
+
+    /**
+     * @throws ConnectionException always, enriched with the last PHP error when present.
+     */
+    private function throwWriteError(): never
+    {
+        $message = self::WRITE_ERROR_MESSAGE;
+        $error = error_get_last();
+
+        if ($error !== null && $error['message'] !== '') {
+            $message .= ' ' . $error['message'];
+        }
+
+        throw new ConnectionException($message);
+    }
+}

--- a/src/FreeDSx/Socket/Timeout/WriteTimeoutEnforcerInterface.php
+++ b/src/FreeDSx/Socket/Timeout/WriteTimeoutEnforcerInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx Socket package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Socket\Timeout;
+
+use FreeDSx\Socket\Exception\ConnectionException;
+use FreeDSx\Socket\Exception\WriteTimeoutException;
+
+/**
+ * Strategy for writing all bytes to a stream while bounding a stalled send.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface WriteTimeoutEnforcerInterface
+{
+    /**
+     * Write all the data, requiring progress within the timeout (seconds).
+     *
+     * @param resource $stream
+     * @throws WriteTimeoutException when the send makes no progress within the timeout.
+     * @throws ConnectionException on a write failure.
+     */
+    public function write(
+        $stream,
+        string $data,
+        int $timeout,
+    ): void;
+}

--- a/tests/unit/SocketOptionsTest.php
+++ b/tests/unit/SocketOptionsTest.php
@@ -16,6 +16,8 @@ namespace Tests\Unit\FreeDSx\Socket;
 use FreeDSx\Socket\SocketOptions;
 use FreeDSx\Socket\SocketPoolOptions;
 use FreeDSx\Socket\SocketServerOptions;
+use FreeDSx\Socket\Timeout\BlockingSelectEnforcer;
+use FreeDSx\Socket\Timeout\SwooleTimerEnforcer;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
@@ -95,6 +97,25 @@ final class SocketOptionsTest extends TestCase
     public function test_server_options_should_default_idle_timeout_to_600(): void
     {
         self::assertSame(600, (new SocketServerOptions())->getIdleTimeout());
+    }
+
+    public function test_it_defaults_to_the_blocking_select_write_timeout_enforcer(): void
+    {
+        self::assertInstanceOf(
+            BlockingSelectEnforcer::class,
+            (new SocketOptions())->getWriteTimeoutEnforcer(),
+        );
+    }
+
+    public function test_it_can_set_the_write_timeout_enforcer(): void
+    {
+        $enforcer = new SwooleTimerEnforcer();
+        $options = (new SocketOptions())->setWriteTimeoutEnforcer($enforcer);
+
+        self::assertSame(
+            $enforcer,
+            $options->getWriteTimeoutEnforcer(),
+        );
     }
 
     public function test_pool_options_default_to_one_second_connect_timeout(): void

--- a/tests/unit/Timeout/BlockingSelectEnforcerTest.php
+++ b/tests/unit/Timeout/BlockingSelectEnforcerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx Socket package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Socket\Timeout;
+
+use FreeDSx\Socket\Exception\WriteTimeoutException;
+use FreeDSx\Socket\Timeout\BlockingSelectEnforcer;
+use PHPUnit\Framework\TestCase;
+
+final class BlockingSelectEnforcerTest extends TestCase
+{
+    private BlockingSelectEnforcer $subject;
+
+    /**
+     * @var resource|null
+     */
+    private $local;
+
+    /**
+     * @var resource|null
+     */
+    private $remote;
+
+    protected function setUp(): void
+    {
+        $this->subject = new BlockingSelectEnforcer();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_resource($this->remote)) {
+            fclose($this->remote);
+        }
+        if (is_resource($this->local)) {
+            fclose($this->local);
+        }
+    }
+
+    public function test_it_sends_all_data_when_the_peer_reads(): void
+    {
+        [$local, $remote] = $this->createSocketPair();
+
+        $this->subject->write(
+            $local,
+            '0123456789',
+            5,
+        );
+
+        self::assertSame(
+            '0123456789',
+            fread($remote, 10),
+        );
+    }
+
+    public function test_it_restores_blocking_mode_after_a_successful_write(): void
+    {
+        [$local] = $this->createSocketPair();
+
+        $this->subject->write(
+            $local,
+            '0123456789',
+            5,
+        );
+
+        self::assertTrue(stream_get_meta_data($local)['blocked']);
+    }
+
+    public function test_it_throws_when_the_peer_stops_reading(): void
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            self::markTestSkipped('Cannot fill the socket to force a send stall on Windows.');
+        }
+
+        [$local] = $this->createSocketPair();
+
+        $this->expectException(WriteTimeoutException::class);
+
+        $this->subject->write(
+            $local,
+            str_repeat('x', 32 * 1024 * 1024),
+            1,
+        );
+    }
+
+    /**
+     * @return array{0: resource, 1: resource}
+     */
+    private function createSocketPair(): array
+    {
+        $pair = stream_socket_pair(
+            DIRECTORY_SEPARATOR === '\\' ? STREAM_PF_INET : STREAM_PF_UNIX,
+            STREAM_SOCK_STREAM,
+            STREAM_IPPROTO_IP,
+        );
+        if ($pair === false) {
+            self::fail('Failed to create socket pair.');
+        }
+        [$this->local, $this->remote] = $pair;
+
+        return [
+            $pair[0],
+            $pair[1],
+        ];
+    }
+}

--- a/tests/unit/Timeout/SwooleTimerEnforcerTest.php
+++ b/tests/unit/Timeout/SwooleTimerEnforcerTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx Socket package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Socket\Timeout;
+
+use FreeDSx\Socket\Exception\WriteTimeoutException;
+use FreeDSx\Socket\Timeout\SwooleTimerEnforcer;
+use PHPUnit\Framework\TestCase;
+use Swoole\Coroutine;
+use Swoole\Runtime;
+use Throwable;
+
+final class SwooleTimerEnforcerTest extends TestCase
+{
+    private SwooleTimerEnforcer $subject;
+
+    protected function setUp(): void
+    {
+        if (!extension_loaded('swoole')) {
+            self::markTestSkipped('The swoole extension is required.');
+        }
+        if (DIRECTORY_SEPARATOR === '\\') {
+            self::markTestSkipped('Cannot fill the socket to force a send stall on Windows.');
+        }
+
+        $this->subject = new SwooleTimerEnforcer();
+    }
+
+    public function test_it_falls_back_to_the_blocking_select_loop_outside_a_coroutine(): void
+    {
+        [$local, $remote] = $this->createSocketPair();
+
+        try {
+            $this->expectException(WriteTimeoutException::class);
+
+            $this->subject->write(
+                $local,
+                str_repeat('x', 32 * 1024 * 1024),
+                1,
+            );
+        } finally {
+            fclose($local);
+            fclose($remote);
+        }
+    }
+
+    public function test_it_sends_all_data_inside_a_coroutine(): void
+    {
+        $received = null;
+        $this->runInCoroutine(function () use (&$received): void {
+            [$local, $remote] = $this->createSocketPair();
+
+            try {
+                $this->subject->write(
+                    $local,
+                    '0123456789',
+                    5,
+                );
+                $received = fread($remote, 10);
+            } finally {
+                fclose($local);
+                fclose($remote);
+            }
+        });
+
+        self::assertSame(
+            '0123456789',
+            $received,
+        );
+    }
+
+    public function test_it_throws_a_write_timeout_inside_a_coroutine_when_the_peer_stalls(): void
+    {
+        $caught = null;
+        $this->runInCoroutine(function () use (&$caught): void {
+            [$local, $remote] = $this->createSocketPair();
+
+            try {
+                $this->subject->write(
+                    $local,
+                    str_repeat('x', 32 * 1024 * 1024),
+                    1,
+                );
+            } catch (Throwable $e) {
+                $caught = $e;
+            } finally {
+                fclose($local);
+                fclose($remote);
+            }
+        });
+
+        self::assertInstanceOf(
+            WriteTimeoutException::class,
+            $caught,
+        );
+    }
+
+    private function runInCoroutine(callable $callback): void
+    {
+        Runtime::enableCoroutine(SWOOLE_HOOK_ALL);
+
+        try {
+            Coroutine\run($callback);
+        } finally {
+            Runtime::enableCoroutine(0);
+        }
+    }
+
+    /**
+     * @return array{0: resource, 1: resource}
+     */
+    private function createSocketPair(): array
+    {
+        $pair = stream_socket_pair(
+            STREAM_PF_UNIX,
+            STREAM_SOCK_STREAM,
+            STREAM_IPPROTO_IP,
+        );
+        if ($pair === false) {
+            self::fail('Failed to create socket pair.');
+        }
+
+        return [$pair[0], $pair[1]];
+    }
+}


### PR DESCRIPTION
This is needed to make a distinction between coroutine strategies like swoole vs non-coroutine (which is fine with `stream_select`). Without this the coroutine paths struggle with performance issues due to how stream_select is hooked (under swoole anyway).