### PR TITLE
Add an IdleTimeoutException.

### DIFF
--- a/src/FreeDSx/Socket/Exception/IdleTimeoutException.php
+++ b/src/FreeDSx/Socket/Exception/IdleTimeoutException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx Socket package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Socket\Exception;
+
+/**
+ * Thrown when a blocking read makes no progress within the configured read timeout.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class IdleTimeoutException extends ConnectionException
+{
+}

--- a/src/FreeDSx/Socket/Socket.php
+++ b/src/FreeDSx/Socket/Socket.php
@@ -14,12 +14,15 @@ declare(strict_types=1);
 namespace FreeDSx\Socket;
 
 use FreeDSx\Socket\Exception\ConnectionException;
+use FreeDSx\Socket\Exception\IdleTimeoutException;
 use FreeDSx\Socket\Timeout\WriteTimeoutEnforcerInterface;
 
 use function fclose;
 use function fread;
 use function fwrite;
+use function sprintf;
 use function stream_context_create;
+use function stream_get_meta_data;
 use function stream_set_blocking;
 use function stream_set_timeout;
 use function stream_socket_client;
@@ -66,6 +69,9 @@ class Socket
         }
     }
 
+    /**
+     * @throws IdleTimeoutException when a blocking read makes no progress within the configured read timeout.
+     */
     public function read(bool $block = true): string|false
     {
         $stream = $this->getStream();
@@ -75,6 +81,15 @@ class Socket
             $stream,
             $this->options->getBufferSize(),
         );
+
+        // A blocking read yields no bytes on either a peer disconnect (feof, empty string) or a read timeout
+        // (false). Only the timeout case sets the timed_out meta flag, which distinguishes the two.
+        if ($block && ($data === '' || $data === false) && $this->hasReadTimedOut($stream)) {
+            throw new IdleTimeoutException(sprintf(
+                'The connection was idle for longer than the read timeout of %d seconds.',
+                $this->options->getTimeoutRead(),
+            ));
+        }
 
         if (!$block) {
             stream_set_blocking(
@@ -86,6 +101,15 @@ class Socket
         return $data === ''
             ? false
             : $data;
+    }
+
+    /**
+     * @param resource $stream
+     */
+    private function hasReadTimedOut($stream): bool
+    {
+        return $this->options->getTimeoutRead() > 0
+            && stream_get_meta_data($stream)['timed_out'] === true;
     }
 
     public function write(string $data): static

--- a/tests/unit/SocketTest.php
+++ b/tests/unit/SocketTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Socket;
 
+use FreeDSx\Socket\Exception\IdleTimeoutException;
 use FreeDSx\Socket\Exception\WriteTimeoutException;
 use FreeDSx\Socket\Socket;
 use FreeDSx\Socket\SocketOptions;
@@ -266,6 +267,30 @@ final class SocketTest extends TestCase
         $subject = new Socket($local);
 
         self::assertFalse($subject->read());
+    }
+
+    public function test_it_should_throw_an_idle_timeout_when_a_blocking_read_exceeds_the_read_timeout(): void
+    {
+        [$local] = $this->createSocketPair();
+        $subject = new Socket(
+            $local,
+            (new SocketOptions())->setTimeoutRead(1),
+        );
+
+        $this->expectException(IdleTimeoutException::class);
+
+        $subject->read();
+    }
+
+    public function test_it_should_not_throw_an_idle_timeout_on_a_non_blocking_read(): void
+    {
+        [$local] = $this->createSocketPair();
+        $subject = new Socket(
+            $local,
+            (new SocketOptions())->setTimeoutRead(1),
+        );
+
+        self::assertFalse($subject->read(false));
     }
 
     public function test_it_should_leave_the_socket_in_blocking_mode_after_a_non_blocking_read(): void


### PR DESCRIPTION
Need this so we can distinguish an idle timeout from other connection issues. This helps the metrics for the LDAP library.