### PR TITLE
Allow getting the peer's TLS certificate.

### DIFF
--- a/src/FreeDSx/Socket/Socket.php
+++ b/src/FreeDSx/Socket/Socket.php
@@ -16,12 +16,16 @@ namespace FreeDSx\Socket;
 use FreeDSx\Socket\Exception\ConnectionException;
 use FreeDSx\Socket\Exception\IdleTimeoutException;
 use FreeDSx\Socket\Timeout\WriteTimeoutEnforcerInterface;
+use FreeDSx\Socket\Tls\Certificate;
+use OpenSSLCertificate;
 
 use function fclose;
 use function fread;
 use function fwrite;
+use function is_array;
 use function sprintf;
 use function stream_context_create;
+use function stream_context_get_options;
 use function stream_get_meta_data;
 use function stream_set_blocking;
 use function stream_set_timeout;
@@ -164,6 +168,25 @@ class Socket
     public function isEncrypted(): bool
     {
         return $this->isEncrypted;
+    }
+
+    /**
+     * The peer's verified TLS certificate, if one was presented during the handshake.
+     */
+    public function getPeerCertificate(): ?Certificate
+    {
+        if ($this->socket === null) {
+            return null;
+        }
+
+        $ssl = stream_context_get_options($this->socket)['ssl'] ?? null;
+        $peer = is_array($ssl)
+            ? ($ssl['peer_certificate'] ?? null)
+            : null;
+
+        return $peer instanceof OpenSSLCertificate
+            ? Certificate::fromX509($peer)
+            : null;
     }
 
     /**

--- a/src/FreeDSx/Socket/Tls/Certificate.php
+++ b/src/FreeDSx/Socket/Tls/Certificate.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx Socket package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Socket\Tls;
+
+use OpenSSLCertificate;
+
+use function array_filter;
+use function array_values;
+use function is_array;
+use function is_string;
+use function openssl_x509_parse;
+
+/**
+ * An abstraction over a parsed peer X.509 certificate, so the OpenSSL extension type is not exposed to consumers.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class Certificate
+{
+    /**
+     * @param array<array-key, mixed> $parsed
+     */
+    private function __construct(private array $parsed)
+    {
+    }
+
+    /**
+     * Parse a verified peer certificate, or null when it cannot be parsed.
+     */
+    public static function fromX509(OpenSSLCertificate $certificate): ?self
+    {
+        $parsed = openssl_x509_parse($certificate);
+
+        return $parsed === false
+            ? null
+            : new self($parsed);
+    }
+
+    /**
+     * The subject relative distinguished name components, e.g. ['CN' => 'foo', 'O' => 'Acme'].
+     *
+     * @return array<string, string|list<string>>
+     */
+    public function getSubject(): array
+    {
+        $subject = $this->parsed['subject'] ?? [];
+        if (!is_array($subject)) {
+            return [];
+        }
+
+        $components = [];
+        foreach ($subject as $name => $value) {
+            if (!is_string($name)) {
+                continue;
+            }
+
+            if (is_string($value)) {
+                $components[$name] = $value;
+            } elseif (is_array($value)) {
+                $components[$name] = array_values(array_filter($value, 'is_string'));
+            }
+        }
+
+        return $components;
+    }
+
+    /**
+     * The raw OpenSSL-formatted subjectAltName extension (e.g. "DNS:foo.local, email:a@b.local"), or null if absent.
+     */
+    public function getSubjectAltName(): ?string
+    {
+        $extensions = $this->parsed['extensions'] ?? [];
+        $san = is_array($extensions)
+            ? ($extensions['subjectAltName'] ?? null)
+            : null;
+
+        return is_string($san)
+            ? $san
+            : null;
+    }
+}

--- a/tests/unit/SocketTest.php
+++ b/tests/unit/SocketTest.php
@@ -17,7 +17,11 @@ use FreeDSx\Socket\Exception\IdleTimeoutException;
 use FreeDSx\Socket\Exception\WriteTimeoutException;
 use FreeDSx\Socket\Socket;
 use FreeDSx\Socket\SocketOptions;
+use FreeDSx\Socket\Tls\Certificate;
 use FreeDSx\Socket\Transport;
+use OpenSSLAsymmetricKey;
+use OpenSSLCertificate;
+use OpenSSLCertificateSigningRequest;
 use PHPUnit\Framework\TestCase;
 
 final class SocketTest extends TestCase
@@ -301,6 +305,58 @@ final class SocketTest extends TestCase
         $subject->read(false);
 
         self::assertTrue(stream_get_meta_data($local)['blocked']);
+    }
+
+    public function test_it_should_return_null_for_the_peer_certificate_when_not_connected(): void
+    {
+        self::assertNull((new Socket())->getPeerCertificate());
+    }
+
+    public function test_it_should_return_null_for_the_peer_certificate_when_none_was_presented(): void
+    {
+        [$local] = $this->createSocketPair();
+        $subject = new Socket($local);
+
+        self::assertNull($subject->getPeerCertificate());
+    }
+
+    public function test_it_should_return_the_peer_certificate_when_one_was_presented(): void
+    {
+        [$local] = $this->createSocketPair();
+        stream_context_set_option($local, 'ssl', 'peer_certificate', $this->makeCertificate());
+        $subject = new Socket($local);
+
+        $certificate = $subject->getPeerCertificate();
+
+        self::assertInstanceOf(
+            Certificate::class,
+            $certificate,
+        );
+        self::assertSame(
+            'peer.test',
+            $certificate->getSubject()['CN'] ?? null,
+        );
+    }
+
+    private function makeCertificate(): OpenSSLCertificate
+    {
+        $key = openssl_pkey_new(['private_key_bits' => 2048]);
+        if (!$key instanceof OpenSSLAsymmetricKey) {
+            self::fail('Failed to generate a private key.');
+        }
+
+        // openssl_csr_new() takes the key by reference, so re-narrow both after the call.
+        $csr = openssl_csr_new(['commonName' => 'peer.test'], $key);
+        if (!$csr instanceof OpenSSLCertificateSigningRequest || !$key instanceof OpenSSLAsymmetricKey) {
+            self::fail('Failed to generate a certificate signing request.');
+        }
+
+        $certificate = openssl_csr_sign($csr, null, $key, 1);
+        if (!$certificate instanceof OpenSSLCertificate) {
+            self::fail('Failed to sign the certificate.');
+        }
+
+        return $certificate;
     }
 
     /**

--- a/tests/unit/Tls/CertificateTest.php
+++ b/tests/unit/Tls/CertificateTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx Socket package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Socket\Tls;
+
+use FreeDSx\Socket\Tls\Certificate;
+use OpenSSLCertificate;
+use PHPUnit\Framework\TestCase;
+
+final class CertificateTest extends TestCase
+{
+    /**
+     * Throwaway self-signed cert generated for this test.
+     *
+     *  - subject "/CN=test.local/O=FreeDSx/C=US",
+     *  - SAN "DNS:test.local, email:test@freedsx.local"
+     *
+     * openssl req -x509 -newkey rsa:2048 -nodes -days 36500
+     */
+    private const FIXTURE_PEM = <<<'PEM'
+        -----BEGIN CERTIFICATE-----
+        MIIDdjCCAl6gAwIBAgIUdHEhFVr/VYCaS+SDgabMMlhPVUQwDQYJKoZIhvcNAQEL
+        BQAwNDETMBEGA1UEAwwKdGVzdC5sb2NhbDEQMA4GA1UECgwHRnJlZURTeDELMAkG
+        A1UEBhMCVVMwIBcNMjYwNjA3MjAyNzQzWhgPMjEyNjA1MTQyMDI3NDNaMDQxEzAR
+        BgNVBAMMCnRlc3QubG9jYWwxEDAOBgNVBAoMB0ZyZWVEU3gxCzAJBgNVBAYTAlVT
+        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmU5G97cRIK/1RXPQoQSc
+        Ce8tyXSJa3pFln/P/MR++isQTN3GENvFRLqpVZqjDZY81HbpH6/zmXNLiFFkp3HC
+        Nk9VOCO5q22/ZN3m7jBPOWhUTmqgppmtqEeRzBq4tMOqtqvyAtMISKPYzrdCj6bs
+        ZG/D5zWoWDDRSBQ4mjaMMFe68pf85WqUDi9qfLSQoHx5iLbbyGc2Z5/uzUysOlJN
+        qR7BqNbpdpnrDt4BbnBj5rUjvLZZXRIqfBtQgLV7si2g2zyOiEdQFblkwiJZi83v
+        246akDrwxAjYaVnpJ+eCmgTBUflzSbUjR80DBLYPpCA3D+nqnfDbEdP6aotZb4Mn
+        IQIDAQABo34wfDAdBgNVHQ4EFgQUhD5XlhQ+ZvreIt5jarm8yzlRSMcwHwYDVR0j
+        BBgwFoAUhD5XlhQ+ZvreIt5jarm8yzlRSMcwDwYDVR0TAQH/BAUwAwEB/zApBgNV
+        HREEIjAgggp0ZXN0LmxvY2FsgRJ0ZXN0QGZyZWVkc3gubG9jYWwwDQYJKoZIhvcN
+        AQELBQADggEBAHdo7kq5ddOPwW3VGCgXLdPe0zZ22G6NzJdnv53+QN/h1Z0ugHRY
+        t+iTy2HX4ssRSph/lNqp1BfkU0T7+MPy0A/VJlVVcISUc/1lfr5NTYs6MUNvVIzQ
+        vy/Ehi/0C9L5pg06ECeLGMYKnwe77JzgW+LrhPz2Wp+I4fDMHp++AsoN6Yn4NLot
+        kutr6oGylPInZL8CQMf7y89C0QtJxa6U8mjC7Mx4YwcAjIiKNJeKJHLQG6lopJKz
+        HWERWoTCuR1106b2fyedXz7ZwRtZFmalQiZeg8TIt3WKzElWSLHl72SBtLFHafSB
+        WiIEba05kUnSLRk97yfqFO53Mv2KsUz6HUc=
+        -----END CERTIFICATE-----
+        PEM;
+
+    public function testItExposesTheSubject(): void
+    {
+        $certificate = Certificate::fromX509($this->fixture());
+
+        self::assertSame(
+            [
+                'CN' => 'test.local',
+                'O' => 'FreeDSx',
+                'C' => 'US',
+            ],
+            $certificate?->getSubject(),
+        );
+    }
+
+    public function testItExposesTheSubjectAltName(): void
+    {
+        $certificate = Certificate::fromX509($this->fixture());
+
+        self::assertSame(
+            'DNS:test.local, email:test@freedsx.local',
+            $certificate?->getSubjectAltName(),
+        );
+    }
+
+    private function fixture(): OpenSSLCertificate
+    {
+        $certificate = openssl_x509_read(self::FIXTURE_PEM);
+        self::assertInstanceOf(
+            OpenSSLCertificate::class,
+            $certificate,
+        );
+
+        return $certificate;
+    }
+}


### PR DESCRIPTION
This allows getting the peers certificate. Specifically, I need this on the LDAP side for verification purposes for EXTERNAL sasl auth.