### PR TITLE
Do not verify the peer's name by default for the socket server.

### DIFF
--- a/src/FreeDSx/Socket/HasSocketOptions.php
+++ b/src/FreeDSx/Socket/HasSocketOptions.php
@@ -39,6 +39,8 @@ trait HasSocketOptions
 
     private bool $sslValidateCert = true;
 
+    private ?bool $sslVerifyPeerName = null;
+
     private ?bool $sslAllowSelfSigned = null;
 
     private ?string $sslCaCert = null;
@@ -132,6 +134,24 @@ trait HasSocketOptions
     public function isSslValidateCert(): bool
     {
         return $this->sslValidateCert;
+    }
+
+    /**
+     * Whether to verify the peer's name (hostname). Null follows the validate-cert setting.
+     *
+     * Note: A server verifying a client certificate should set this false. There is no hostname to match on a client
+     *       certificate.
+     */
+    public function setSslVerifyPeerName(?bool $sslVerifyPeerName): self
+    {
+        $this->sslVerifyPeerName = $sslVerifyPeerName;
+
+        return $this;
+    }
+
+    public function getSslVerifyPeerName(): ?bool
+    {
+        return $this->sslVerifyPeerName;
     }
 
     public function setSslAllowSelfSigned(?bool $sslAllowSelfSigned): self
@@ -280,7 +300,7 @@ trait HasSocketOptions
         $opts = [
             'allow_self_signed' => $this->sslAllowSelfSigned ?? false,
             'verify_peer' => $this->sslValidateCert,
-            'verify_peer_name' => $this->sslValidateCert,
+            'verify_peer_name' => $this->sslVerifyPeerName ?? $this->sslValidateCert,
             'capture_peer_cert' => true,
             'capture_peer_cert_chain' => true,
             'crypto_method' => $this->sslCryptoMethod,

--- a/src/FreeDSx/Socket/SocketServerOptions.php
+++ b/src/FreeDSx/Socket/SocketServerOptions.php
@@ -27,6 +27,8 @@ final class SocketServerOptions implements SocketOptionsInterface
     public function __construct()
     {
         $this->setSslValidateCert(false);
+        // A server verifies the client certificate chains to a trusted CA, never that it matches a hostname.
+        $this->setSslVerifyPeerName(false);
         $this->setSslCryptoMethod(
             STREAM_CRYPTO_METHOD_TLSv1_2_SERVER
             | STREAM_CRYPTO_METHOD_TLSv1_1_SERVER

--- a/tests/unit/SocketOptionsTest.php
+++ b/tests/unit/SocketOptionsTest.php
@@ -72,6 +72,16 @@ final class SocketOptionsTest extends TestCase
         self::assertFalse($ctx['allow_self_signed']);
     }
 
+    public function test_it_can_verify_the_peer_without_verifying_its_name(): void
+    {
+        $ctx = (new SocketOptions())
+            ->setSslVerifyPeerName(false)
+            ->toStreamContextSslOptions();
+
+        self::assertTrue($ctx['verify_peer']);
+        self::assertFalse($ctx['verify_peer_name']);
+    }
+
     public function test_set_buffer_size_must_be_positive(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -82,6 +92,11 @@ final class SocketOptionsTest extends TestCase
     public function test_server_options_should_disable_certificate_validation_by_default(): void
     {
         self::assertFalse((new SocketServerOptions())->isSslValidateCert());
+    }
+
+    public function test_server_options_should_not_verify_the_peer_name_by_default(): void
+    {
+        self::assertFalse((new SocketServerOptions())->toStreamContextSslOptions()['verify_peer_name']);
     }
 
     public function test_server_options_should_use_server_side_crypto_method_by_default(): void


### PR DESCRIPTION
There's no real reason for the server to have this setting on by default. Switching it to off.